### PR TITLE
 Add Send constraint on the builder fn 

### DIFF
--- a/examples/thread_pool.rs
+++ b/examples/thread_pool.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 fn main() {
     // Use static variable to label the threads as they're spawned
-    static mut THREAD_INDEX : usize = 0;
+    static mut THREAD_INDEX: usize = 0;
 
     let thread_spawner = || -> io::Result<_> {
         let index = unsafe {
@@ -40,7 +40,12 @@ fn main() {
         // We can handle initial thread spawn failures here
         .expect("Thread spawns");
 
-    let messages = vec!["Good day.", "How do you do.", "Hola.", "Top of the morning to ya."];
+    let messages = vec![
+        "Good day.",
+        "How do you do.",
+        "Hola.",
+        "Top of the morning to ya.",
+    ];
     for message in messages {
         // We can handle thread spawn failures here if they occur
         let handle = pool.get().expect("Thread spawns");

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -1,4 +1,4 @@
-use super::{Pool, BoxedConstructor};
+use super::{BoxedConstructor, Pool};
 
 use std::result::Result;
 
@@ -21,14 +21,11 @@ where
 impl<TPool> Builder<TPool>
 where
     TPool: Pool,
-    Builder<TPool>: Build<TPool>
+    Builder<TPool>: Build<TPool>,
 {
-    pub fn new<F> (
-        pool_size: usize,
-        constructor: F,
-    ) -> Builder<TPool>
+    pub fn new<F>(pool_size: usize, constructor: F) -> Builder<TPool>
     where
-        F: 'static + Fn() -> Result<TPool::Item, TPool::ConstructionError>
+        F: 'static + Fn() -> Result<TPool::Item, TPool::ConstructionError>,
     {
         let constructor = Box::new(constructor);
 

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -25,7 +25,7 @@ where
 {
     pub fn new<F>(pool_size: usize, constructor: F) -> Builder<TPool>
     where
-        F: 'static + Fn() -> Result<TPool::Item, TPool::ConstructionError>,
+        F: 'static + Send + Fn() -> Result<TPool::Item, TPool::ConstructionError>,
     {
         let constructor = Box::new(constructor);
 

--- a/src/pool/macros.rs
+++ b/src/pool/macros.rs
@@ -1,7 +1,7 @@
 macro_rules! pub_builder_fn {
     ($pool_type:ident) => {
         /// Get the builder for the pool.
-        pub fn builder<F: 'static + Fn() -> Result<T, TCError>>(
+        pub fn builder<F: 'static + Send + Fn() -> Result<T, TCError>>(
             pool_size: usize,
             constructor: F,
         ) -> Builder<$pool_type<T, TCError>> {

--- a/src/pool/macros.rs
+++ b/src/pool/macros.rs
@@ -4,11 +4,10 @@ macro_rules! pub_builder_fn {
         pub fn builder<F: 'static + Fn() -> Result<T, TCError>>(
             pool_size: usize,
             constructor: F,
-        ) -> Builder<$pool_type<T, TCError>>
-        {
+        ) -> Builder<$pool_type<T, TCError>> {
             Builder::new(pool_size, constructor)
         }
-    }
+    };
 }
 
 macro_rules! pub_pool_fns {

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -1,12 +1,13 @@
 use std::ops::{Deref, DerefMut};
 
-#[macro_use] mod macros;
+#[macro_use]
+mod macros;
 mod builder;
 mod round_robin_pool;
 
 pub use self::round_robin_pool::RoundRobinPool;
 
-type BoxedConstructor<T, TError> = Box<Fn() -> Result<T, TError>>;
+type BoxedConstructor<T, TError> = Box<dyn Fn() -> Result<T, TError>>;
 
 /// An object which returns re-used items. Pools hold on to a constructor
 /// so they can recreate elements that are invalid (marked by user).
@@ -47,7 +48,10 @@ impl<T> ItemHandle<T> {
     }
 
     pub(crate) fn new(item: T) -> ItemHandle<T> {
-        ItemHandle { item, invalid: false, }
+        ItemHandle {
+            item,
+            invalid: false,
+        }
     }
 
     pub(crate) fn into_item(self) -> T {

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -7,7 +7,7 @@ mod round_robin_pool;
 
 pub use self::round_robin_pool::RoundRobinPool;
 
-type BoxedConstructor<T, TError> = Box<dyn Fn() -> Result<T, TError>>;
+type BoxedConstructor<T, TError> = Box<dyn Send + Fn() -> Result<T, TError>>;
 
 /// An object which returns re-used items. Pools hold on to a constructor
 /// so they can recreate elements that are invalid (marked by user).

--- a/src/pool/round_robin_pool.rs
+++ b/src/pool/round_robin_pool.rs
@@ -1,5 +1,5 @@
-use super::{ItemHandle, BoxedConstructor, Pool};
-use super::builder::{Builder, Build};
+use super::builder::{Build, Builder};
+use super::{BoxedConstructor, ItemHandle, Pool};
 
 /// A [`Pool`] that uses round-robin logic to retrieve items
 /// in the pool. Can be converted into the items with the `into_items()` function.
@@ -17,15 +17,15 @@ impl<T, TCError> RoundRobinPool<T, TCError> {
         self.items.len()
     }
 
-    pub fn into_items(self) -> impl Iterator<Item=T> {
+    pub fn into_items(self) -> impl Iterator<Item = T> {
         self.items.into_iter().map(|h| h.into_item())
     }
 
-    pub fn items_iter(&self) -> impl Iterator<Item=&T> {
+    pub fn items_iter(&self) -> impl Iterator<Item = &T> {
         self.items.iter().map(|h| h.as_item())
     }
 
-    pub fn items_iter_mut(&mut self) -> impl Iterator<Item=&mut T> {
+    pub fn items_iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
         self.items.iter_mut().map(|h| h.as_item_mut())
     }
 }
@@ -34,8 +34,7 @@ impl<T, TCError> Pool for RoundRobinPool<T, TCError> {
     type Item = T;
     type ConstructionError = TCError;
 
-    fn get(&mut self) -> Result<&mut ItemHandle<T>, TCError>
-    {
+    fn get(&mut self) -> Result<&mut ItemHandle<T>, TCError> {
         let invalid = self.items[self.index].invalid();
         if invalid {
             self.items[self.index] = ItemHandle::new((self.constructor)()?);
@@ -47,11 +46,13 @@ impl<T, TCError> Pool for RoundRobinPool<T, TCError> {
     }
 }
 
-impl<T, TCError>
-    Build<RoundRobinPool<T, TCError>> for Builder<RoundRobinPool<T, TCError>>
-{
+impl<T, TCError> Build<RoundRobinPool<T, TCError>> for Builder<RoundRobinPool<T, TCError>> {
     fn build(self) -> Result<RoundRobinPool<T, TCError>, TCError> {
-        let Builder { pool_size, constructor, .. } = self;
+        let Builder {
+            pool_size,
+            constructor,
+            ..
+        } = self;
 
         let mut items = Vec::with_capacity(pool_size);
         for _ in 0..pool_size {
@@ -72,14 +73,12 @@ mod tests {
 
     #[test]
     fn works_in_round_robin_fashion() {
-        static mut INDEX : usize = 0;
+        static mut INDEX: usize = 0;
 
-        let constructor = || {
-            unsafe {
-                let old_index = INDEX;
-                INDEX += 1;
-                Ok(old_index)
-            }
+        let constructor = || unsafe {
+            let old_index = INDEX;
+            INDEX += 1;
+            Ok(old_index)
         };
 
         let mut pool = RoundRobinPool::<_, ()>::builder(5, constructor)
@@ -101,14 +100,12 @@ mod tests {
 
     #[test]
     fn refills_items_as_expected() {
-        static mut INDEX : usize = 0;
+        static mut INDEX: usize = 0;
 
-        let constructor = || {
-            unsafe {
-                let old_index = INDEX;
-                INDEX += 1;
-                Ok(old_index)
-            }
+        let constructor = || unsafe {
+            let old_index = INDEX;
+            INDEX += 1;
+            Ok(old_index)
         };
 
         let mut pool = RoundRobinPool::<_, ()>::builder(5, constructor)


### PR DESCRIPTION
Currently, you cannot send a Pool across threads because the fn trait object does not impl send. This PR fixes that, and runs cargo fmt on the source.