### PR TITLE
Bump to version 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fpool"
-version = "0.4.0"
+version = "0.5.0"
 license = "MIT"
 authors = ["Darren Tsung <darren@onesignal.com>"]
 description = "Non-leased object-pooling."


### PR DESCRIPTION
Because we added a Send constraint on the constructor fn,
we need to indicate a breaking change was made.